### PR TITLE
Fix out of bounds in tdigest_compute_quantiles

### DIFF
--- a/tdigest.c
+++ b/tdigest.c
@@ -497,6 +497,17 @@ tdigest_compute_quantiles(tdigest_aggstate_t *state, double *result)
 
 		on_the_right = (delta > 0.0);
 
+		/*
+		 * for extreme percentiles we might end on the right of the last node or on the
+		 * left of the first node, instead of interpolating we return the mean of the node
+		 */
+		if ((on_the_right && (j+1) >= state->ncentroids) ||
+			(!on_the_right && (j-1) <= 0))
+		{
+			result[i] = (c->sum / c->count);
+			continue;
+		}
+
 		if (on_the_right)
 		{
 			prev = &state->centroids[j];

--- a/tdigest.c
+++ b/tdigest.c
@@ -502,7 +502,7 @@ tdigest_compute_quantiles(tdigest_aggstate_t *state, double *result)
 		 * left of the first node, instead of interpolating we return the mean of the node
 		 */
 		if ((on_the_right && (j+1) >= state->ncentroids) ||
-			(!on_the_right && (j-1) <= 0))
+			(!on_the_right && (j-1) < 0))
 		{
 			result[i] = (c->sum / c->count);
 			continue;

--- a/tdigest.c
+++ b/tdigest.c
@@ -100,6 +100,7 @@ static int  centroid_cmp(const void *a, const void *b);
  * and memory usage.
  */
 #define	BUFFER_SIZE(compression)	(10 * (compression))
+#define AssertBounds(index, length) Assert((index) >= 0 && (index) < (length))
 
 #define MIN_COMPRESSION		10
 #define MAX_COMPRESSION		10000
@@ -499,11 +500,13 @@ tdigest_compute_quantiles(tdigest_aggstate_t *state, double *result)
 		if (on_the_right)
 		{
 			prev = &state->centroids[j];
+			AssertBounds(j+1, state->ncentroids);
 			next = &state->centroids[j+1];
 			count += (prev->count / 2.0);
 		}
 		else
 		{
+			AssertBounds(j-1, state->ncentroids);
 			prev = &state->centroids[j-1];
 			next = &state->centroids[j];
 			count -= (prev->count / 2.0);

--- a/test/expected/tdigest.out
+++ b/test/expected/tdigest.out
@@ -1258,3 +1258,22 @@ FROM (
  0.99 | t        |    
 (6 rows)
 
+-- verify 'extreme' percentiles for the dataset would not read out of bounds on the centroids
+WITH data AS (SELECT x FROM generate_series(1,10) AS x)
+SELECT
+    p,
+    abs(a - b) < 0.1, -- arbitrary threshold of 10% given the small dataset and extreme percentiles it is not very accurate
+    (CASE WHEN abs(a - b) < 0.1 THEN NULL ELSE (a - b) END) AS err
+FROM (
+    SELECT
+        unnest(ARRAY[0.01, 0.99]) AS p,
+        unnest(tdigest_percentile(x, 10, ARRAY[0.01, 0.99])) AS a,
+        unnest(percentile_cont(ARRAY[0.01, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
+    FROM data
+) foo;
+  p   | ?column? | err 
+------+----------+-----
+ 0.01 | t        |    
+ 0.99 | t        |    
+(2 rows)
+


### PR DESCRIPTION
During our integration within Citus we ran into an edge case where certain quantile lookups would cause out of bounds access to the `centroids` array.

The cases happened when you are looking up a quantile that is on the right side of the last centroid or on the left of the first.

The algorithm linked from the readme had an extra check that would prevent these cases: https://github.com/ajwerner/tdigestc/blob/a2a61e660188bffabf687f2fce1785439c994936/go/tdigest.c#L195-L199

This PR consists of the following changes;
 - Adding an assert that verifies our access to the centroids array is within bounds
 - Adding a simple test case that triggers both errors described above
 - A fix that returns the current centroids mean to prevent out of bounds access. This fix is inline with the original algorithms check linked above.

---
Special thanks to @min-mwei for pointing this out to us and pointing to where he thought the culprit was; https://github.com/min-mwei/tdigest/commit/9869a334e394f9411bdecdb37cf7c968c6629690
