### PR TITLE
Add <value, count> API 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ MODULE_big = tdigest
 OBJS = tdigest.o
 
 EXTENSION = tdigest
-DATA = tdigest--1.0.0.sql
+EXTVERSIONS = 1.0.1
+DATA_built = $(foreach v,$(EXTVERSIONS),$(EXTENSION)--$(v).sql)
+DATA = $(wildcard $(EXTENSION)--*--*.sql)
 MODULES = tdigest
 
 CFLAGS=`pg_config --includedir-server`
@@ -14,3 +16,6 @@ REGRESS_OPTS = --inputdir=test
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+
+$(EXTENSION)--1.0.1.sql: $(EXTENSION)--1.0.0.sql $(EXTENSION)--1.0.0--1.0.1.sql
+	cat $^ > $@

--- a/tdigest--1.0.0--1.0.1.sql
+++ b/tdigest--1.0.0--1.0.1.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE FUNCTION tdigest_add_double_count(p_pointer internal, p_element double precision, p_count bigint, p_compression int)
+    RETURNS internal
+    AS 'tdigest', 'tdigest_add_double_count'
+    LANGUAGE C IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION tdigest_add_double_count(p_pointer internal, p_element double precision, p_count bigint, p_compression int, p_quantile double precision)
+    RETURNS internal
+    AS 'tdigest', 'tdigest_add_double_count'
+    LANGUAGE C IMMUTABLE;
+
+CREATE AGGREGATE tdigest(double precision, bigint, int) (
+    SFUNC = tdigest_add_double_count,
+    STYPE = internal,
+    FINALFUNC = tdigest_digest,
+    SERIALFUNC = tdigest_serial,
+    DESERIALFUNC = tdigest_deserial,
+    COMBINEFUNC = tdigest_combine,
+    PARALLEL = SAFE
+);
+
+CREATE AGGREGATE tdigest_percentile(double precision, bigint, int, double precision) (
+    SFUNC = tdigest_add_double_count,
+    STYPE = internal,
+    FINALFUNC = tdigest_percentiles,
+    SERIALFUNC = tdigest_serial,
+    DESERIALFUNC = tdigest_deserial,
+    COMBINEFUNC = tdigest_combine,
+    PARALLEL = SAFE
+);

--- a/tdigest.c
+++ b/tdigest.c
@@ -882,7 +882,7 @@ tdigest_add_double_count(PG_FUNCTION_ARGS)
 
 	/* cannot be called directly because of internal-type argument */
 	if (!AggCheckCallContext(fcinfo, &aggcontext))
-		elog(ERROR, "tdigest_add_double called in non-aggregate context");
+		elog(ERROR, "tdigest_add_double_count called in non-aggregate context");
 
 	/*
 	 * We want to skip NULL values altogether - we return either the existing

--- a/tdigest.c
+++ b/tdigest.c
@@ -877,7 +877,7 @@ Datum
 tdigest_add_double_count(PG_FUNCTION_ARGS)
 {
 	tdigest_aggstate_t *state;
-
+	int64 count;
 	MemoryContext aggcontext;
 
 	/* cannot be called directly because of internal-type argument */
@@ -929,8 +929,13 @@ tdigest_add_double_count(PG_FUNCTION_ARGS)
 	else
 		state = (tdigest_aggstate_t *) PG_GETARG_POINTER(0);
 
-	tdigest_add_centroid(state, PG_GETARG_FLOAT8(1), PG_GETARG_INT64(2));
-
+	if (PG_ARGISNULL(2))
+	{
+		count = 1;
+	}
+	else
+		count = PG_GETARG_INT64(2);
+	tdigest_add_centroid(state, PG_GETARG_FLOAT8(1), count);
 	PG_RETURN_POINTER(state);
 }
 

--- a/tdigest.control
+++ b/tdigest.control
@@ -1,3 +1,3 @@
 comment = 'Provides quantile aggregate function.'
-default_version = '1.0.0'
+default_version = '1.0.1'
 relocatable = true

--- a/test/expected/tdigest.out
+++ b/test/expected/tdigest.out
@@ -78,14 +78,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -102,7 +102,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -119,14 +119,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -143,7 +143,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -160,14 +160,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -184,7 +184,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -204,14 +204,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -228,7 +228,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -245,14 +245,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -269,7 +269,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -286,14 +286,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -310,7 +310,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -330,14 +330,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -354,7 +354,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -371,14 +371,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -395,7 +395,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -412,14 +412,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -436,7 +436,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -456,14 +456,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -480,7 +480,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -497,14 +497,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -521,7 +521,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -538,14 +538,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -562,7 +562,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -582,14 +582,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -606,7 +606,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -623,14 +623,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -647,7 +647,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -664,14 +664,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -688,7 +688,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -708,14 +708,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -732,7 +732,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -749,14 +749,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -773,7 +773,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -790,14 +790,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -814,7 +814,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -834,14 +834,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -858,7 +858,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -875,14 +875,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -899,7 +899,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -916,14 +916,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -940,7 +940,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -960,14 +960,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -984,7 +984,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -1001,14 +1001,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -1025,7 +1025,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -1042,14 +1042,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -1066,7 +1066,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -1086,14 +1086,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -1110,7 +1110,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -1127,14 +1127,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -1151,7 +1151,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -1168,14 +1168,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -1192,7 +1192,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b 
+ p | a | b
 ---+---+---
 (0 rows)
 
@@ -1214,14 +1214,14 @@ FROM (
     FROM tdigest_parsed,
          pg_percentile
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- verify we can store tdigest in a summary table
@@ -1248,14 +1248,14 @@ FROM (
     FROM intermediate,
          pg_percentile
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.05 | t        |    
-  0.1 | t        |    
-  0.9 | t        |    
- 0.95 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.05 | t        |
+  0.1 | t        |
+  0.9 | t        |
+ 0.95 | t        |
+ 0.99 | t        |
 (6 rows)
 
 -- verify 'extreme' percentiles for the dataset would not read out of bounds on the centroids
@@ -1271,9 +1271,20 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err 
+  p   | ?column? | err
 ------+----------+-----
- 0.01 | t        |    
- 0.99 | t        |    
+ 0.01 | t        |
+ 0.99 | t        |
 (2 rows)
 
+-- verify <value, count> API
+select sum(tdigest_count(t)), round(tdigest_percentile(t, 0.5)::numeric, 2)
+ from (
+ select tdigest(v*w, w, 100) as t
+ from (
+ select unnest(v) as v, unnest(w) as w from (select ARRAY[0.1,0.2,0.3] as v,  ARRAY[50,50,100] as w) as q
+ ) as s) as s;
+ sum | round
+-----+-------
+ 200 |  0.23
+(1 row)

--- a/test/expected/tdigest.out
+++ b/test/expected/tdigest.out
@@ -78,14 +78,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -102,7 +102,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -119,14 +119,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -143,7 +143,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -160,14 +160,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -184,7 +184,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -204,14 +204,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -228,7 +228,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -245,14 +245,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -269,7 +269,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -286,14 +286,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -310,7 +310,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -330,14 +330,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -354,7 +354,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -371,14 +371,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -395,7 +395,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -412,14 +412,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -436,7 +436,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -456,14 +456,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -480,7 +480,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -497,14 +497,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -521,7 +521,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -538,14 +538,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -562,7 +562,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -582,14 +582,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -606,7 +606,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -623,14 +623,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -647,7 +647,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -664,14 +664,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -688,7 +688,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -708,14 +708,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -732,7 +732,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -749,14 +749,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -773,7 +773,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -790,14 +790,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -814,7 +814,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -834,14 +834,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -858,7 +858,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -875,14 +875,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -899,7 +899,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -916,14 +916,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -940,7 +940,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -960,14 +960,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -984,7 +984,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -1001,14 +1001,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -1025,7 +1025,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -1042,14 +1042,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -1066,7 +1066,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -1086,14 +1086,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -1110,7 +1110,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 10, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -1127,14 +1127,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -1151,7 +1151,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 100, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -1168,14 +1168,14 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- make sure the resulting percentiles are in the right order
@@ -1192,7 +1192,7 @@ SELECT * FROM (
             unnest(tdigest_percentile(x, 1000, (SELECT p FROM perc))) AS a
         FROM data
     ) foo ) bar WHERE a <= b;
- p | a | b
+ p | a | b 
 ---+---+---
 (0 rows)
 
@@ -1214,14 +1214,14 @@ FROM (
     FROM tdigest_parsed,
          pg_percentile
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- verify we can store tdigest in a summary table
@@ -1248,14 +1248,14 @@ FROM (
     FROM intermediate,
          pg_percentile
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.05 | t        |
-  0.1 | t        |
-  0.9 | t        |
- 0.95 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.05 | t        |    
+  0.1 | t        |    
+  0.9 | t        |    
+ 0.95 | t        |    
+ 0.99 | t        |    
 (6 rows)
 
 -- verify 'extreme' percentiles for the dataset would not read out of bounds on the centroids
@@ -1271,10 +1271,10 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
-  p   | ?column? | err
+  p   | ?column? | err 
 ------+----------+-----
- 0.01 | t        |
- 0.99 | t        |
+ 0.01 | t        |    
+ 0.99 | t        |    
 (2 rows)
 
 -- verify <value, count> API

--- a/test/expected/tdigest.out
+++ b/test/expected/tdigest.out
@@ -1,4 +1,44 @@
-\set ECHO none
+SET
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+psql:tdigest--1.0.0.sql:70: ERROR:  function "tdigest_percentile" already exists with same argument types
+psql:tdigest--1.0.0.sql:80: ERROR:  function "tdigest_percentile" already exists with same argument types
+psql:tdigest--1.0.0.sql:90: ERROR:  function "tdigest_percentile_of" already exists with same argument types
+psql:tdigest--1.0.0.sql:100: ERROR:  function "tdigest_percentile_of" already exists with same argument types
+psql:tdigest--1.0.0.sql:102: ERROR:  type "tdigest" already exists
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+psql:tdigest--1.0.0.sql:131: ERROR:  type "tdigest" already exists
+CREATE FUNCTION
+psql:tdigest--1.0.0.sql:146: ERROR:  function "tdigest" already exists with same argument types
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+psql:tdigest--1.0.0.sql:181: ERROR:  function "tdigest_percentile" already exists with same argument types
+psql:tdigest--1.0.0.sql:191: ERROR:  function "tdigest_percentile" already exists with same argument types
+psql:tdigest--1.0.0.sql:201: ERROR:  function "tdigest_percentile_of" already exists with same argument types
+psql:tdigest--1.0.0.sql:211: ERROR:  function "tdigest_percentile_of" already exists with same argument types
+psql:tdigest--1.0.0.sql:221: ERROR:  function "tdigest" already exists with same argument types
+CREATE FUNCTION
+CREATE FUNCTION
+CREATE FUNCTION
+psql:tdigest--1.0.0--1.0.1.sql:19: ERROR:  function "tdigest" already exists with same argument types
+psql:tdigest--1.0.0--1.0.1.sql:29: ERROR:  function "tdigest_percentile" already exists with same argument types
+SET
 -- SRF function implementing a simple deterministict PRNG
 CREATE OR REPLACE FUNCTION prng(nrows int, seed int = 23982, p1 bigint = 16807, p2 bigint = 0, n bigint = 2147483647) RETURNS SETOF double precision AS $$
 DECLARE
@@ -13,6 +53,7 @@ BEGIN
     RETURN;
 END;
 $$ LANGUAGE plpgsql;
+CREATE FUNCTION
 CREATE OR REPLACE FUNCTION random_normal(nrows int, mean double precision = 0.5, stddev double precision = 0.1, minval double precision = 0.0, maxval double precision = 1.0, seed int = 23982, p1 bigint = 16807, p2 bigint = 0, n bigint = 2147483647) RETURNS SETOF double precision AS $$
 DECLARE
     v BIGINT := seed;
@@ -62,6 +103,7 @@ BEGIN
 
 END;
 $$ LANGUAGE plpgsql;
+CREATE FUNCTION
 -----------------------------------------------------------
 -- nice data set with ordered (asc) / evenly-spaced data --
 -----------------------------------------------------------
@@ -1226,6 +1268,7 @@ FROM (
 
 -- verify we can store tdigest in a summary table
 CREATE TABLE intermediate_tdigest (grouping int, summary tdigest);
+psql:test/sql/tdigest.sql:917: ERROR:  relation "intermediate_tdigest" already exists
 WITH data AS (SELECT row_number() OVER () AS i, pow(z, 4) AS x FROM random_normal(1000000) s(z))
 INSERT INTO intermediate_tdigest
 SELECT
@@ -1233,6 +1276,7 @@ SELECT
     tdigest(x, 100) AS summary
 FROM data
 GROUP BY i % 10;
+INSERT 0 10
 WITH data AS (SELECT pow(z, 4) AS x FROM random_normal(1000000) s(z)),
      intermediate AS (SELECT tdigest_percentile(summary, ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) AS a FROM intermediate_tdigest),
      pg_percentile AS (SELECT percentile_cont(ARRAY[0.01, 0.05, 0.1, 0.9, 0.95, 0.99]) WITHIN GROUP (ORDER BY x) AS b FROM data)
@@ -1277,6 +1321,11 @@ FROM (
  0.99 | t        |    
 (2 rows)
 
+drop extension tdigest CASCADE;
+psql:test/sql/tdigest.sql:957: NOTICE:  drop cascades to column summary of table intermediate_tdigest
+DROP EXTENSION
+create extension tdigest;
+CREATE EXTENSION
 -- verify <value, count> API
 select sum(tdigest_count(t)), round(tdigest_percentile(t, 0.5)::numeric, 2)
  from (
@@ -1284,7 +1333,7 @@ select sum(tdigest_count(t)), round(tdigest_percentile(t, 0.5)::numeric, 2)
  from (
  select unnest(v) as v, unnest(w) as w from (select ARRAY[0.1,0.2,0.3] as v,  ARRAY[50,50,100] as w) as q
  ) as s) as s;
- sum | round
+ sum | round 
 -----+-------
  200 |  0.23
 (1 row)
@@ -1298,3 +1347,26 @@ select round(tdigest_percentile(v*w, w, 100, 0.5)::numeric, 2) as p50
 ------
  0.23
 (1 row)
+
+-- verify <value, count> API when count is null
+select sum(tdigest_count(t)), round(tdigest_percentile(t, 0.5)::numeric, 2)
+ from (
+ select tdigest(v*w, null, 100) as t
+ from (
+ select unnest(v) as v, unnest(w) as w from (select ARRAY[0.1,0.2,0.3] as v,  ARRAY[50,50,100] as w) as q
+ ) as s) as s;
+ sum | round 
+-----+-------
+   3 | 10.00
+(1 row)
+
+-- verify tdigest_percentile(double precision, bigint, int, double precision) API when count is null
+select round(tdigest_percentile(v*w, null, 100, 0.5)::numeric, 2) as p50
+ from (
+ select unnest(v) as v, unnest(w) as w from (select ARRAY[0.1,0.2,0.3] as v,  ARRAY[50,50,100] as w) as q
+) as s;
+  p50  
+-------
+ 10.00
+(1 row)
+

--- a/test/expected/tdigest.out
+++ b/test/expected/tdigest.out
@@ -1288,3 +1288,13 @@ select sum(tdigest_count(t)), round(tdigest_percentile(t, 0.5)::numeric, 2)
 -----+-------
  200 |  0.23
 (1 row)
+
+-- verify tdigest_percentile(double precision, bigint, int, double precision) API
+select round(tdigest_percentile(v*w, w, 100, 0.5)::numeric, 2) as p50
+ from (
+ select unnest(v) as v, unnest(w) as w from (select ARRAY[0.1,0.2,0.3] as v,  ARRAY[50,50,100] as w) as q
+) as s;
+ p50  
+------
+ 0.23
+(1 row)

--- a/test/sql/tdigest.sql
+++ b/test/sql/tdigest.sql
@@ -954,6 +954,9 @@ FROM (
     FROM data
 ) foo;
 
+drop extension tdigest CASCADE;
+create extension tdigest;
+
 -- verify <value, count> API
 select sum(tdigest_count(t)), round(tdigest_percentile(t, 0.5)::numeric, 2)
  from (
@@ -964,6 +967,20 @@ select sum(tdigest_count(t)), round(tdigest_percentile(t, 0.5)::numeric, 2)
 
 -- verify tdigest_percentile(double precision, bigint, int, double precision) API
 select round(tdigest_percentile(v*w, w, 100, 0.5)::numeric, 2) as p50
+ from (
+ select unnest(v) as v, unnest(w) as w from (select ARRAY[0.1,0.2,0.3] as v,  ARRAY[50,50,100] as w) as q
+) as s;
+
+-- verify <value, count> API when count is null
+select sum(tdigest_count(t)), round(tdigest_percentile(t, 0.5)::numeric, 2)
+ from (
+ select tdigest(v*w, null, 100) as t
+ from (
+ select unnest(v) as v, unnest(w) as w from (select ARRAY[0.1,0.2,0.3] as v,  ARRAY[50,50,100] as w) as q
+ ) as s) as s;
+
+-- verify tdigest_percentile(double precision, bigint, int, double precision) API when count is null
+select round(tdigest_percentile(v*w, null, 100, 0.5)::numeric, 2) as p50
  from (
  select unnest(v) as v, unnest(w) as w from (select ARRAY[0.1,0.2,0.3] as v,  ARRAY[50,50,100] as w) as q
 ) as s;

--- a/test/sql/tdigest.sql
+++ b/test/sql/tdigest.sql
@@ -961,3 +961,9 @@ select sum(tdigest_count(t)), round(tdigest_percentile(t, 0.5)::numeric, 2)
  from (
  select unnest(v) as v, unnest(w) as w from (select ARRAY[0.1,0.2,0.3] as v,  ARRAY[50,50,100] as w) as q
  ) as s) as s;
+
+-- verify tdigest_percentile(double precision, bigint, int, double precision) API
+select round(tdigest_percentile(v*w, w, 100, 0.5)::numeric, 2) as p50
+ from (
+ select unnest(v) as v, unnest(w) as w from (select ARRAY[0.1,0.2,0.3] as v,  ARRAY[50,50,100] as w) as q
+) as s;

--- a/test/sql/tdigest.sql
+++ b/test/sql/tdigest.sql
@@ -3,6 +3,7 @@
 -- disable the notices for the create script (shell types etc.)
 SET client_min_messages = 'WARNING';
 \i tdigest--1.0.0.sql
+\i tdigest--1.0.0--1.0.1.sql
 SET client_min_messages = 'NOTICE';
 
 \set ECHO all
@@ -952,3 +953,11 @@ FROM (
         unnest(percentile_cont(ARRAY[0.01, 0.99]) WITHIN GROUP (ORDER BY x)) AS b
     FROM data
 ) foo;
+
+-- verify <value, count> API
+select sum(tdigest_count(t)), round(tdigest_percentile(t, 0.5)::numeric, 2)
+ from (
+ select tdigest(v*w, w, 100) as t
+ from (
+ select unnest(v) as v, unnest(w) as w from (select ARRAY[0.1,0.2,0.3] as v,  ARRAY[50,50,100] as w) as q
+ ) as s) as s;


### PR DESCRIPTION
The use case is that, the data input, instead of an array of doubles, could be <value, count> pairs, say, <0.1, 100>, <0.2, 50> that there are 100 occurrences of value 0.1, 50 occurrences of 0.2. Effectively these are centroids from the calculation's perspective. 

In conversation with @thanodnl who is adding support for tdigest in Citus, I created this separate pull request to create the API in the tdigest core first.  

I am trying to follow the spirit of the current API design, please feel free to make alternative suggestions. Also implementation wise I think it's better to duplicate the C code a bit to make the intent clearer. 

Please let me know what you think. Support this API is essential for my use case (as the count could be very big and make it impossible to use the existing SQL API).  Thanks, --min