### PR TITLE
WIP: experimental building of histograms from tdigest

### DIFF
--- a/tdigest--1.0.0--1.1.0.sql
+++ b/tdigest--1.0.0--1.1.0.sql
@@ -1,0 +1,43 @@
+CREATE OR REPLACE FUNCTION equiwidth_histogram(p_digest tdigest, p_bins int)
+RETURNS TABLE (bin_start double precision,
+               bin_end double precision,
+               bin_density double precision)
+AS $$
+
+    WITH
+      range  AS (SELECT tdigest_percentile(p_digest, 0.0) AS min_value, tdigest_percentile(p_digest, 1.0) AS max_value),
+      bounds AS (SELECT
+                     range.min_value + (i - 1) * (range.max_value - range.min_value) / p_bins AS bin_start,
+                     range.min_value + i * (range.max_value - range.min_value) / p_bins AS bin_end
+                 FROM range, generate_series(1,p_bins) AS s(i))
+      SELECT
+          bounds.bin_start,
+          bounds.bin_end,
+          tdigest_percentile_of(p_digest, bounds.bin_end) - tdigest_percentile_of(p_digest, bounds.bin_start)
+      FROM bounds
+      GROUP BY 1, 2
+      ORDER BY 1, 2;
+
+$$ LANGUAGE sql;
+
+
+CREATE OR REPLACE FUNCTION equiheight_histogram(p_digest tdigest, p_bins int)
+RETURNS TABLE (bin_start double precision,
+               bin_end double precision,
+               bin_density double precision)
+AS $$
+
+    WITH
+      freqs AS (SELECT
+                     (i - 1)::double precision / p_bins AS freq_start,
+                     i::double precision / p_bins AS freq_end
+                 FROM generate_series(1,p_bins) AS s(i))
+      SELECT
+          tdigest_percentile(p_digest, freqs.freq_start),
+          tdigest_percentile(p_digest, freqs.freq_end),
+          freqs.freq_end - freqs.freq_start
+      FROM freqs
+      GROUP BY freqs.freq_start, freqs.freq_end
+      ORDER BY 1, 2;
+
+$$ LANGUAGE sql;

--- a/tdigest.control
+++ b/tdigest.control
@@ -1,3 +1,3 @@
 comment = 'Provides quantile aggregate function.'
-default_version = '1.0.0'
+default_version = '1.1.0'
 relocatable = true


### PR DESCRIPTION
This implements two simple SQL functions, building different types of
histograms from a t-digest. Equi-width histograms are the "usual" type
with each bin covering about 1/N of the domain, while equi-height
histograms have bins representing the same fraction of the data.

The functions are fairly trivial SQL functions, calculating boundaries
on either the domain or frequency, and then computing the other values
using the t-digest.

I'm not sure how accurate the histograms are - considering how t-digests
work, the bins at the ends should be the fine while the bins in the
middle could be somewhat less accurate.

One thing this made me realize is the extension only provides aggregate
functions, so when we need to work with t-digests in non-aggregate
contexts it's necessary to do unnecessary groupings etc. Might be handy
to provide some non-aggregate functions to make that unnecessary.