### PR TITLE
WIP support for incremental updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MODULE_big = tdigest
 OBJS = tdigest.o
 
 EXTENSION = tdigest
-DATA = tdigest--1.0.0.sql tdigest--1.0.0--1.0.1.sql
+DATA = tdigest--1.0.0.sql tdigest--1.0.0--1.0.1.sql tdigest--1.0.1--1.1.0.sql
 MODULES = tdigest
 
 CFLAGS=`pg_config --includedir-server`

--- a/tdigest--1.0.1--1.1.0.sql
+++ b/tdigest--1.0.1--1.1.0.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION tdigest_add(p_digest tdigest, p_element double precision, p_compression int = NULL, p_compact bool = true)
+    RETURNS tdigest
+    AS 'tdigest', 'tdigest_add_double_increment'
+    LANGUAGE C IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION tdigest_add(p_digest tdigest, p_elements double precision[], p_compression int = NULL, p_compact bool = true)
+    RETURNS tdigest
+    AS 'tdigest', 'tdigest_add_double_array_increment'
+    LANGUAGE C IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION tdigest_union(p_digest1 tdigest, p_digest2 tdigest, p_compact bool = true)
+    RETURNS tdigest
+    AS 'tdigest', 'tdigest_union_double_increment'
+    LANGUAGE C IMMUTABLE;

--- a/tdigest.c
+++ b/tdigest.c
@@ -85,6 +85,8 @@ typedef struct tdigest_aggstate_t {
 
 static int  centroid_cmp(const void *a, const void *b);
 
+#define PG_GETARG_TDIGEST(x)	(tdigest_t *) PG_DETOAST_DATUM(PG_GETARG_DATUM(x))
+
 /*
  * Size of buffer for incoming data, as a multiple of the compression value.
  * Quoting from the t-digest paper:
@@ -133,6 +135,10 @@ PG_FUNCTION_INFO_V1(tdigest_recv);
 
 PG_FUNCTION_INFO_V1(tdigest_count);
 
+PG_FUNCTION_INFO_V1(tdigest_add_double_increment);
+PG_FUNCTION_INFO_V1(tdigest_add_double_array_increment);
+PG_FUNCTION_INFO_V1(tdigest_union_double_increment);
+
 Datum tdigest_add_double_array(PG_FUNCTION_ARGS);
 Datum tdigest_add_double_array_values(PG_FUNCTION_ARGS);
 Datum tdigest_add_double(PG_FUNCTION_ARGS);
@@ -160,6 +166,10 @@ Datum tdigest_send(PG_FUNCTION_ARGS);
 Datum tdigest_recv(PG_FUNCTION_ARGS);
 
 Datum tdigest_count(PG_FUNCTION_ARGS);
+
+Datum tdigest_add_double_increment(PG_FUNCTION_ARGS);
+Datum tdigest_add_double_array_increment(PG_FUNCTION_ARGS);
+Datum tdigest_union_double_increment(PG_FUNCTION_ARGS);
 
 static Datum double_to_array(FunctionCallInfo fcinfo, double * d, int len);
 static double *array_to_double(FunctionCallInfo fcinfo, ArrayType *v, int * len);
@@ -757,12 +767,13 @@ tdigest_aggstate_allocate(int npercentiles, int nvalues, int compression)
 }
 
 static tdigest_t *
-tdigest_aggstate_to_digest(tdigest_aggstate_t *state)
+tdigest_aggstate_to_digest(tdigest_aggstate_t *state, bool compact)
 {
 	int			i;
 	tdigest_t  *digest;
 
-	tdigest_compact(state);
+	if (compact)
+		tdigest_compact(state);
 
 	digest = tdigest_allocate(state->ncentroids);
 
@@ -867,6 +878,7 @@ tdigest_add_double(PG_FUNCTION_ARGS)
 
 	PG_RETURN_POINTER(state);
 }
+
 
 /*
  * Add a value to the tdigest (create one if needed). Transition function
@@ -1412,7 +1424,7 @@ tdigest_digest(PG_FUNCTION_ARGS)
 
 	state = (tdigest_aggstate_t *) PG_GETARG_POINTER(0);
 
-	digest = tdigest_aggstate_to_digest(state);
+	digest = tdigest_aggstate_to_digest(state, true);
 
 	PG_RETURN_POINTER(digest);
 }
@@ -1657,6 +1669,197 @@ tdigest_combine(PG_FUNCTION_ARGS)
 
 	PG_RETURN_POINTER(dst);
 }
+
+/* API for incremental updates */
+
+/*
+ * expand the t-digest into an in-memory aggregate state
+ */
+static tdigest_aggstate_t *
+tdigest_digest_to_aggstate(tdigest_t *digest)
+{
+	int					i;
+	tdigest_aggstate_t *state;
+
+	/* make sure the t-digest format is supported */
+	if (digest->flags != 0)
+		elog(ERROR, "unsupported t-digest on-disk format");
+
+	state = tdigest_aggstate_allocate(0, 0, digest->compression);
+
+	/* copy data from the tdigest into the aggstate */
+	for (i = 0; i < digest->ncentroids; i++)
+		tdigest_add_centroid(state,
+							 digest->centroids[i].sum,
+							 digest->centroids[i].count);
+
+	return state;
+}
+
+/*
+ * Add a single value to the t-digest. This is not very efficient, as it has
+ * to deserialize the t-digest into the in-memory aggstate representation
+ * and serialize it back for each call, but it's convenient and acceptable
+ * for some use cases.
+ *
+ * When efficiency is important, it may be possible to use the batch variant
+ * with first aggregating the updates into a t-digest, and then merge that
+ * into an existing t-digest in one step using tdigest_union_double_increment
+ *
+ * This is similar to hll_add, while the "union" is more like hll_union.
+ */
+Datum
+tdigest_add_double_increment(PG_FUNCTION_ARGS)
+{
+	tdigest_aggstate_t *state;
+	bool				compact = PG_GETARG_BOOL(3);
+
+	/*
+	 * We want to skip NULL values altogether - we return either the existing
+	 * t-digest (if it already exists) or NULL.
+	 */
+	if (PG_ARGISNULL(1))
+	{
+		if (PG_ARGISNULL(0))
+			PG_RETURN_NULL();
+
+		/* if there already is a state accumulated, don't forget it */
+		PG_RETURN_DATUM(PG_GETARG_DATUM(0));
+	}
+
+	/* if there's no digest allocated, create it now */
+	if (PG_ARGISNULL(0))
+	{
+		int		compression;
+
+		/*
+		 * We don't require compression, but only when there is an existing
+		 * t-digest value. Make sure the value was supplied.
+		 */
+		if (PG_ARGISNULL(2))
+			elog(ERROR, "compression value not supplied, but t-digest is NULL");
+
+		compression = PG_GETARG_INT32(2);
+
+		check_compression(compression);
+
+		state = tdigest_aggstate_allocate(0, 0, compression);
+	}
+	else
+		state = tdigest_digest_to_aggstate(PG_GETARG_TDIGEST(0));
+
+	tdigest_add(state, PG_GETARG_FLOAT8(1));
+
+	PG_RETURN_POINTER(tdigest_aggstate_to_digest(state, compact));
+}
+
+/*
+ * Add an array of values to the t-digest. This amortizes the overhead of
+ * deserializing and serializing the t-digest, compared to the per-value
+ * version.
+ *
+ * When efficiency is important, it may be possible to use the batch variant
+ * with first aggregating the updates into a t-digest, and then merge that
+ * into an existing t-digest in one step using tdigest_union_double_increment
+ *
+ * This is similar to hll_add, while the "union" is more like hll_union.
+ */
+Datum
+tdigest_add_double_array_increment(PG_FUNCTION_ARGS)
+{
+	tdigest_aggstate_t *state;
+	bool				compact = PG_GETARG_BOOL(3);
+	double			   *values;
+	int					nvalues;
+	int					i;
+
+	/*
+	 * We want to skip NULL values altogether - we return either the existing
+	 * t-digest (if it already exists) or NULL.
+	 */
+	if (PG_ARGISNULL(1))
+	{
+		if (PG_ARGISNULL(0))
+			PG_RETURN_NULL();
+
+		/* if there already is a state accumulated, don't forget it */
+		PG_RETURN_DATUM(PG_GETARG_DATUM(0));
+	}
+
+	/* if there's no digest allocated, create it now */
+	if (PG_ARGISNULL(0))
+	{
+		int		compression;
+
+		/*
+		 * We don't require compression, but only when there is an existing
+		 * t-digest value. Make sure the value was supplied.
+		 */
+		if (PG_ARGISNULL(2))
+			elog(ERROR, "compression value not supplied, but t-digest is NULL");
+
+		compression = PG_GETARG_INT32(2);
+
+		check_compression(compression);
+
+		state = tdigest_aggstate_allocate(0, 0, compression);
+	}
+	else
+		state = tdigest_digest_to_aggstate(PG_GETARG_TDIGEST(0));
+
+	values = array_to_double(fcinfo,
+							 PG_GETARG_ARRAYTYPE_P(1),
+							 &nvalues);
+
+	for (i = 0; i < nvalues; i++)
+		tdigest_add(state, values[i]);
+
+	PG_RETURN_POINTER(tdigest_aggstate_to_digest(state, compact));
+}
+
+/*
+ * Merge a t-digest into another t-digest. This is somewaht inefficient, as
+ * it has to deserialize the t-digests into the in-memory aggstate values,
+ * and serialize it back for each call, but it's better than doing it for
+ * each individual value (like tdigest_union_double_increment).
+ *
+ * This is similar to hll_union.
+ */
+Datum
+tdigest_union_double_increment(PG_FUNCTION_ARGS)
+{
+	int					i;
+	tdigest_aggstate_t *state;
+	tdigest_t		   *digest;
+	bool				compact = PG_GETARG_BOOL(2);
+
+	if (PG_ARGISNULL(0) && PG_ARGISNULL(1))
+		PG_RETURN_NULL();
+	else if (PG_ARGISNULL(0))
+		PG_RETURN_POINTER(PG_GETARG_POINTER(1));
+	else if (PG_ARGISNULL(1))
+		PG_RETURN_POINTER(PG_GETARG_POINTER(0));
+
+	/* now we know both arguments are non-null */
+
+	/* parse the first digest (we'll merge the other one into this) */
+	state = tdigest_digest_to_aggstate(PG_GETARG_TDIGEST(0));
+	AssertCheckTDigestAggState(state);
+
+	/* parse the second digest */
+	digest = PG_GETARG_TDIGEST(1);
+	AssertCheckTDigest(digest);
+
+	/* copy data from the tdigest into the aggstate */
+	for (i = 0; i < digest->ncentroids; i++)
+		tdigest_add_centroid(state, digest->centroids[i].sum,
+									digest->centroids[i].count);
+
+	AssertCheckTDigestAggState(state);
+
+	PG_RETURN_POINTER(tdigest_aggstate_to_digest(state, compact));
+}
+
 
 /*
  * Comparator, ordering the centroids by mean value.

--- a/tdigest.control
+++ b/tdigest.control
@@ -1,3 +1,2 @@
 comment = 'Provides tdigest aggregate function.'
-default_version = '1.0.1'
-relocatable = true
+default_version = '1.1.0'

--- a/test/expected/tdigest.out
+++ b/test/expected/tdigest.out
@@ -1297,3 +1297,63 @@ SELECT * FROM (
 ---+----+----
 (0 rows)
 
+-- test incremental API (adding values one by one)
+CREATE TABLE t (d tdigest);
+INSERT INTO t VALUES (NULL);
+-- check this produces the same result building the tdigest at once, but we
+-- need to be careful about feeding the data in the same order, and we must
+-- not compactify the t-digest after each increment
+DO LANGUAGE plpgsql $$
+DECLARE
+  r RECORD;
+BEGIN
+    FOR r IN (SELECT i FROM generate_series(1,1000) s(i) ORDER BY md5(i::text)) LOOP
+        UPDATE t SET d = tdigest_add(d, r.i, 100, false);
+    END LOOP;
+END$$;
+-- compare the results, but do force a compaction of the incremental result
+WITH x AS (SELECT i FROM generate_series(1,1000) s(i) ORDER BY md5(i::text))
+SELECT (SELECT tdigest(d)::text FROM t) = (SELECT tdigest(x.i, 100)::text FROM x) AS match;
+ match 
+-------
+ t
+(1 row)
+
+-- now try the same thing with bulk incremental update (using arrays)
+TRUNCATE t;
+INSERT INTO t VALUES (NULL);
+DO LANGUAGE plpgsql $$
+DECLARE
+  r RECORD;
+BEGIN
+    FOR r IN (SELECT a, array_agg(i::double precision) AS v FROM (SELECT mod(i,5) AS a, i FROM generate_series(1,1000) s(i) ORDER BY mod(i,5), md5(i::text)) foo GROUP BY a ORDER BY a) LOOP
+        UPDATE t SET d = tdigest_add(d, r.v, 100, false);
+    END LOOP;
+END$$;
+-- compare the results, but do force a compaction of the incremental result
+WITH x AS (SELECT mod(i,5) AS a, i::double precision AS d FROM generate_series(1,1000) s(i) ORDER BY mod(i,5), i)
+SELECT (SELECT tdigest(d)::text FROM t) = (SELECT tdigest(x.d, 100)::text FROM x);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- now try the same thing with bulk incremental update (using t-digests)
+TRUNCATE t;
+INSERT INTO t VALUES (NULL);
+DO LANGUAGE plpgsql $$
+DECLARE
+  r RECORD;
+BEGIN
+    FOR r IN (SELECT a, tdigest(i,100) AS d FROM (SELECT mod(i,5) AS a, i FROM generate_series(1,1000) s(i) ORDER BY mod(i,5), md5(i::text)) foo GROUP BY a ORDER BY a) LOOP
+        UPDATE t SET d = tdigest_union(d, r.d, false);
+    END LOOP;
+END$$;
+-- compare the results, but do force a compaction of the incremental result
+WITH x AS (SELECT a, tdigest(i,100) AS d FROM (SELECT mod(i,5) AS a, i FROM generate_series(1,1000) s(i) ORDER BY mod(i,5), md5(i::text)) foo GROUP BY a ORDER BY a)
+SELECT (SELECT tdigest(d)::text FROM t) = (SELECT tdigest(x.d)::text FROM x);
+ ?column? 
+----------
+ t
+(1 row)
+


### PR DESCRIPTION
The current code allows merging of pre-calculated tdigest values, which
is good enough for rollup use cases. But it does not work too well for
cases that require incremental updates, when the digest is updated with
individual values.

This adds two new functions tdigest_add and tdigest_union that should
support these incremental updates. With tdigest_add it's possible to
add a single value to the tdigest value

    UPDATE t SET digest = tdigest_add(digest, x, 100);

while tdigest_union allows 'merging' two digests:

    UPDATE t SET digest = tdigest_union(digest1, digest2);

The idea is similar to hll_add/hll_union from the HLL extension, and we
might even add the same || operator for tdigest_union. Not sure about
the tdigest_add, because we need to specify the compression value for
cases where there's no initial tdigest (i.e. tdigest_add(NULL,x)), and
operators only allow two parameters.

Note: This implementation is probably rather inefficient, because for
each value it performs deserialization, compaction and serialization.
Perhaps there's a way to rethink the representation to save some of this
work (e.g. by making the serialization unnecessary or cheaper). Also,
compacting the digest after each single value might make the digest less
accurate, I guess. So maybe just adding a small buffer would work?